### PR TITLE
Lambda Function と Build Project に環境変数を追加

### DIFF
--- a/lib/test-slack.ts
+++ b/lib/test-slack.ts
@@ -16,9 +16,9 @@ export class TestStack extends cdk.Stack {
           return context.logStreamName;
         };
       `),
-      // environment: {
-      //   "SLACK_CHANNEL": "test-channel",
-      // },
+      environment: {
+        "SLACK_CHANNEL": "test-channel",
+      },
     });
 
     const project = new aws_codebuild.Project(this, "TestProject", {
@@ -32,12 +32,12 @@ export class TestStack extends cdk.Stack {
           },
         },
       }),
-      // environmentVariables: {
-      //   "SLACK_CHANNEL": {
-      //     type: aws_codebuild.BuildEnvironmentVariableType.PLAINTEXT,
-      //     value: "test-channel",
-      //   },
-      // },
+      environmentVariables: {
+        "SLACK_CHANNEL": {
+          type: aws_codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          value: "test-channel",
+        },
+      },
     });
 
     new cdk.CfnOutput(this, "TestFunctionArn", { value: func.functionArn });

--- a/test/__snapshots__/cdk-snapshot-commit.test.ts.snap
+++ b/test/__snapshots__/cdk-snapshot-commit.test.ts.snap
@@ -42,6 +42,11 @@ exports[`Snapshot testing Test Stack 1`] = `
         };
       ",
         },
+        "Environment": {
+          "Variables": {
+            "SLACK_CHANNEL": "test-channel",
+          },
+        },
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -95,6 +100,13 @@ exports[`Snapshot testing Test Stack 1`] = `
         "EncryptionKey": "alias/aws/s3",
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
+          "EnvironmentVariables": [
+            {
+              "Name": "SLACK_CHANNEL",
+              "Type": "PLAINTEXT",
+              "Value": "test-channel",
+            },
+          ],
           "Image": "aws/codebuild/standard:1.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,


### PR DESCRIPTION
Lambda Function と Build Project の環境変数はいずれもリソースプロパティの一部なので、スナップショットを更新すると実際にセットされる環境変数の値もスナップショットの一部として `test/__snapshots__/cdk-snapshot-commit.test.ts.snap` にコミットされてしまう。

Stack リソース側で値を明示せず、例えば `.env` や CLI から引っ張ってくるように変更した場合でも同様。
Stack のソースに値は出てこないがスナップショットの方では解決済みの値が入ってしまう