### PR TITLE
`AWS::Lambda::Function` と `AWS::CodeBuild::Project` の環境変数の値をマスクする Snapshot serializer を追加

### DIFF
--- a/test/__snapshots__/cdk-snapshot-commit.test.ts.snap
+++ b/test/__snapshots__/cdk-snapshot-commit.test.ts.snap
@@ -11,35 +11,29 @@ exports[`Snapshot testing Test Stack 1`] = `
   },
   "Resources": {
     "TestFunctionWithEnvADC2417D": {
-      "DependsOn": [
-        "TestFunctionWithEnvServiceRoleA6AA9548",
-      ],
-      "Properties": {
-        "Code": {
-          "ZipFile": "
-        exports.handler = async function (event, context) {
-          console.log("EVENT: 
-" + JSON.stringify(event, null, 2));
-          return context.logStreamName;
-        };
-      ",
-        },
-        "Environment": {
-          "Variables": {
-            "SLACK_CHANNEL": "test-channel",
-          },
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "TestFunctionWithEnvServiceRoleA6AA9548",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-      },
-      "Type": "AWS::Lambda::Function",
+  "Type": "AWS::Lambda::Function",
+  "Properties": {
+    "Code": {
+      "ZipFile": "\\n        exports.handler = async function (event, context) {\\n          console.log(\\"EVENT: \\n\\" + JSON.stringify(event, null, 2));\\n          return context.logStreamName;\\n        };\\n      "
     },
+    "Environment": {
+      "Variables": {
+        "SLACK_CHANNEL": "***"
+      }
+    },
+    "Handler": "index.handler",
+    "Role": {
+      "Fn::GetAtt": [
+        "TestFunctionWithEnvServiceRoleA6AA9548",
+        "Arn"
+      ]
+    },
+    "Runtime": "nodejs18.x"
+  },
+  "DependsOn": [
+    "TestFunctionWithEnvServiceRoleA6AA9548"
+  ]
+},
     "TestFunctionWithEnvServiceRoleA6AA9548": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -72,30 +66,24 @@ exports[`Snapshot testing Test Stack 1`] = `
       "Type": "AWS::IAM::Role",
     },
     "TestFunctionWithoutEnvF040F9FB": {
-      "DependsOn": [
-        "TestFunctionWithoutEnvServiceRole5D1C6DCC",
-      ],
-      "Properties": {
-        "Code": {
-          "ZipFile": "
-        exports.handler = async function (event, context) {
-          console.log("EVENT: 
-" + JSON.stringify(event, null, 2));
-          return context.logStreamName;
-        };
-      ",
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "TestFunctionWithoutEnvServiceRole5D1C6DCC",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-      },
-      "Type": "AWS::Lambda::Function",
+  "Type": "AWS::Lambda::Function",
+  "Properties": {
+    "Code": {
+      "ZipFile": "\\n        exports.handler = async function (event, context) {\\n          console.log(\\"EVENT: \\n\\" + JSON.stringify(event, null, 2));\\n          return context.logStreamName;\\n        };\\n      "
     },
+    "Handler": "index.handler",
+    "Role": {
+      "Fn::GetAtt": [
+        "TestFunctionWithoutEnvServiceRole5D1C6DCC",
+        "Arn"
+      ]
+    },
+    "Runtime": "nodejs18.x"
+  },
+  "DependsOn": [
+    "TestFunctionWithoutEnvServiceRole5D1C6DCC"
+  ]
+},
     "TestFunctionWithoutEnvServiceRole5D1C6DCC": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -128,50 +116,41 @@ exports[`Snapshot testing Test Stack 1`] = `
       "Type": "AWS::IAM::Role",
     },
     "TestProjectWithEnv44BBE9D1": {
-      "Properties": {
-        "Artifacts": {
-          "Type": "NO_ARTIFACTS",
-        },
-        "Cache": {
-          "Type": "NO_CACHE",
-        },
-        "EncryptionKey": "alias/aws/s3",
-        "Environment": {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "SLACK_CHANNEL",
-              "Type": "PLAINTEXT",
-              "Value": "test-channel",
-            },
-          ],
-          "Image": "aws/codebuild/standard:1.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": {
-          "Fn::GetAtt": [
-            "TestProjectWithEnvRoleA3D98701",
-            "Arn",
-          ],
-        },
-        "Source": {
-          "BuildSpec": "{
-  "version": "0.2",
-  "phases": {
-    "build": {
-      "commands": [
-        "echo hello world"
+  "Type": "AWS::CodeBuild::Project",
+  "Properties": {
+    "Artifacts": {
+      "Type": "NO_ARTIFACTS"
+    },
+    "Cache": {
+      "Type": "NO_CACHE"
+    },
+    "EncryptionKey": "alias/aws/s3",
+    "Environment": {
+      "ComputeType": "BUILD_GENERAL1_SMALL",
+      "EnvironmentVariables": [
+        {
+          "Name": "SLACK_CHANNEL",
+          "Type": "PLAINTEXT",
+          "Value": "***"
+        }
+      ],
+      "Image": "aws/codebuild/standard:1.0",
+      "ImagePullCredentialsType": "CODEBUILD",
+      "PrivilegedMode": false,
+      "Type": "LINUX_CONTAINER"
+    },
+    "ServiceRole": {
+      "Fn::GetAtt": [
+        "TestProjectWithEnvRoleA3D98701",
+        "Arn"
       ]
+    },
+    "Source": {
+      "BuildSpec": "{\\n  \\"version\\": \\"0.2\\",\\n  \\"phases\\": {\\n    \\"build\\": {\\n      \\"commands\\": [\\n        \\"echo hello world\\"\\n      ]\\n    }\\n  }\\n}",
+      "Type": "NO_SOURCE"
     }
   }
-}",
-          "Type": "NO_SOURCE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
+},
     "TestProjectWithEnvRoleA3D98701": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -297,43 +276,34 @@ exports[`Snapshot testing Test Stack 1`] = `
       "Type": "AWS::IAM::Policy",
     },
     "TestProjectWithoutEnv5547A82C": {
-      "Properties": {
-        "Artifacts": {
-          "Type": "NO_ARTIFACTS",
-        },
-        "Cache": {
-          "Type": "NO_CACHE",
-        },
-        "EncryptionKey": "alias/aws/s3",
-        "Environment": {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:1.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": {
-          "Fn::GetAtt": [
-            "TestProjectWithoutEnvRole84EA8F64",
-            "Arn",
-          ],
-        },
-        "Source": {
-          "BuildSpec": "{
-  "version": "0.2",
-  "phases": {
-    "build": {
-      "commands": [
-        "echo hello world"
+  "Type": "AWS::CodeBuild::Project",
+  "Properties": {
+    "Artifacts": {
+      "Type": "NO_ARTIFACTS"
+    },
+    "Cache": {
+      "Type": "NO_CACHE"
+    },
+    "EncryptionKey": "alias/aws/s3",
+    "Environment": {
+      "ComputeType": "BUILD_GENERAL1_SMALL",
+      "Image": "aws/codebuild/standard:1.0",
+      "ImagePullCredentialsType": "CODEBUILD",
+      "PrivilegedMode": false,
+      "Type": "LINUX_CONTAINER"
+    },
+    "ServiceRole": {
+      "Fn::GetAtt": [
+        "TestProjectWithoutEnvRole84EA8F64",
+        "Arn"
       ]
+    },
+    "Source": {
+      "BuildSpec": "{\\n  \\"version\\": \\"0.2\\",\\n  \\"phases\\": {\\n    \\"build\\": {\\n      \\"commands\\": [\\n        \\"echo hello world\\"\\n      ]\\n    }\\n  }\\n}",
+      "Type": "NO_SOURCE"
     }
   }
-}",
-          "Type": "NO_SOURCE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
+},
     "TestProjectWithoutEnvRole84EA8F64": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/test/cdk-snapshot-commit.test.ts
+++ b/test/cdk-snapshot-commit.test.ts
@@ -1,6 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { TestStack } from '../lib/test-slack';
+import { default as Serializer } from './jest-custom-serializer';
+
+expect.addSnapshotSerializer(Serializer);
 
 describe('Snapshot testing', () => {
   test('Test Stack', () => {

--- a/test/jest-custom-serializer.ts
+++ b/test/jest-custom-serializer.ts
@@ -1,0 +1,85 @@
+import { NewPlugin } from 'pretty-format';
+
+type CodeBuildProject = {
+  Type: 'AWS::CodeBuild::Project';
+  Properties: {
+    Environment: {
+      EnvironmentVariables?: {
+        Name: string;
+        Type?: 'PARAMETER_STORE' | 'PLAINTEXT' | 'SECRETS_MANAGER';
+        Value: string;
+      }[],
+      [key: string]: any;
+    },
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+type LambdaFunction = {
+  Type: 'AWS::Lambda::Function';
+  Properties: {
+    Environment?: {
+      Variables?: {
+        [key: string]: string;
+      }
+    },
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+type ExpectedCfnResource = CodeBuildProject | LambdaFunction;
+type Serialize = NewPlugin['serialize'];
+
+const isValidResourceType = (val: any): val is ExpectedCfnResource => {
+  return val.Type && (val.Type === 'AWS::CodeBuild::Project' || val.Type === 'AWS::Lambda::Function')
+    && val.Properties
+    // && (
+    //   val.Properties.Environment // Lambda Function
+    //   && val.Properties.Environment.EnvironmentVariables // CodeBuild Project
+    // )
+};
+
+const serialize: Serialize = (val, config, indentation, depth, refs, printer) => {
+  const toJson = (val: any) => JSON.stringify(val, null, 2);
+
+  if (!isValidResourceType(val)) {
+    return toJson(val);
+  }
+
+  // CloudFormation のリソースタイプに応じて環境変数の値に対応するプロパティをマスクする
+  let result: any;
+  switch (val.Type) {
+    case 'AWS::CodeBuild::Project':
+      result = JSON.parse(JSON.stringify(val));
+      let envVars = val.Properties.Environment.EnvironmentVariables;
+      if (envVars !== undefined) {
+        for (let i = 0; i < envVars.length; i++) {
+          envVars[i].Value = '***';
+        }
+        result.Properties.Environment.EnvironmentVariables = envVars;
+      }
+      break;
+
+    case 'AWS::Lambda::Function':
+      result = JSON.parse(JSON.stringify(val));
+      let envs = val.Properties.Environment?.Variables;
+      if (envs !== undefined) {
+        for (let key of Object.keys(envs)) {
+          envs[key] = '***';
+        }
+        result.Properties.Environment.Variables = envs;
+      }
+      break;
+
+    default:
+      throw new Error(`Unexpected resource: ${val}`);
+  }
+  return toJson(result);
+}
+
+export default {
+  test: isValidResourceType,
+  serialize,
+};


### PR DESCRIPTION
Lambda Function なら `Properties.Environment.Variables` 配下の key/value として、CodeBuild Project なら `Properties.Environment.EnvironmentVariables` 配下の key/value オブジェクトのリストとして環境変数を定義する。

このアプローチでは Jest の Custom Snapshot Serializer を追加する。

リソースタイプに応じて環境変数を定義しているプロパティを拾って、value 部分をマスクしている。

CDK の Construct を直接変更するアプローチは基本的に不可。Construct オブジェクトのプロパティは readonly プロパティであるため、テスト時のみ差し替えという風にはできない。

## 余談

このプルリクエストとは別の案として、beforEach/afterEach で環境変数を一時的に差し替えるような案も、あるにはある。

環境変数への依存があるテストケースはあまり行儀が良いコードとは言えない気がするが、今回の前提条件で目的を達成したいのであればこちらの案もアリだと考えている。Custom serializer と比べてどちらがより一般的な手段かと言われるとこちらの方に分があるような気もしている。。。

この方式は context value からパラメータを拾って Construct を構成するようにしている実装でも応用できる。