### PR TITLE
Stack クラスの props に切り出すことでテスト時にダミー値を注入できるようにした

### DIFF
--- a/lib/test-slack.ts
+++ b/lib/test-slack.ts
@@ -3,8 +3,12 @@ import { Construct } from 'constructs';
 import * as aws_lambda from "aws-cdk-lib/aws-lambda";
 import * as aws_codebuild from "aws-cdk-lib/aws-codebuild";
 
+interface TestSlackProps extends cdk.StackProps {
+  slackChannelId: string;
+}
+
 export class TestStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: TestSlackProps) {
     super(scope, id, props);
 
     /**
@@ -22,9 +26,10 @@ export class TestStack extends cdk.Stack {
       `),
       environment: {
         // Note:
-        // ここでは簡単のため直接チャンネル名に相当する文字列を記述しているが、
-        // 実際には process.env から値を注入し、値がコミットされないように書く想定の箇所
-        "SLACK_CHANNEL": "test-channel",
+        // bin/ 配下のエントリポイントモジュールでは環境変数から取り込むような処理を記述している想定
+        // ただし、Construct クラスの実装としては環境変数かどうかの知識は持たず、単なるパラメータの1つとして扱う
+        // snapshot の作成時にこのクラスのインスタンスを作成する必要があるので、その際にダミー値を渡す。
+        "SLACK_CHANNEL": props.slackChannelId,
       },
     });
 
@@ -59,11 +64,12 @@ export class TestStack extends cdk.Stack {
       }),
       environmentVariables: {
         // Note:
-        // ここでは簡単のため直接チャンネル名に相当する文字列を記述しているが、
-        // 実際には process.env から値を注入し、値がコミットされないように書く想定の箇所
+        // bin/ 配下のエントリポイントモジュールでは環境変数から取り込むような処理を記述している想定
+        // ただし、Construct クラスの実装としては環境変数かどうかの知識は持たず、単なるパラメータの1つとして扱う
+        // snapshot の作成時にこのクラスのインスタンスを作成する必要があるので、その際にダミー値を渡す。
         "SLACK_CHANNEL": {
           type: aws_codebuild.BuildEnvironmentVariableType.PLAINTEXT,
-          value: "test-channel",
+          value: props.slackChannelId,
         },
       },
     });

--- a/test/__snapshots__/cdk-snapshot-commit.test.ts.snap
+++ b/test/__snapshots__/cdk-snapshot-commit.test.ts.snap
@@ -26,7 +26,7 @@ exports[`Snapshot testing Test Stack 1`] = `
         },
         "Environment": {
           "Variables": {
-            "SLACK_CHANNEL": "test-channel",
+            "SLACK_CHANNEL": "***",
           },
         },
         "Handler": "index.handler",
@@ -142,7 +142,7 @@ exports[`Snapshot testing Test Stack 1`] = `
             {
               "Name": "SLACK_CHANNEL",
               "Type": "PLAINTEXT",
-              "Value": "test-channel",
+              "Value": "***",
             },
           ],
           "Image": "aws/codebuild/standard:1.0",

--- a/test/cdk-snapshot-commit.test.ts
+++ b/test/cdk-snapshot-commit.test.ts
@@ -5,7 +5,10 @@ import { TestStack } from '../lib/test-slack';
 describe('Snapshot testing', () => {
   test('Test Stack', () => {
     const app = new cdk.App();
-    const stack = new TestStack(app, 'MyTestStack');
+    const stack = new TestStack(app, 'MyTestStack', {
+      // dummy value
+      slackChannelId: '***',
+    });
 
     const t = Template.fromStack(stack);
     expect(t).toMatchSnapshot();


### PR DESCRIPTION
#3 とは別の回答。

こちらの方がより一般的な testability のアプローチとして推奨される、はず。

このアプローチの欠点を _強いて_ 挙げるとするなら、プログラマの側でどの値がマスクされるべきなのかを把握している必要があること。

#3 の Custom serializer を使った方が楽になりそうなケースは、おそらく同種のリソースを大量展開する想定があった場合でも対応が漏れにくい（本当に...?）ことと、複数の開発者が参画している状況でも値のマスク適用が一貫しやすいことだと考えている